### PR TITLE
Add typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "main": "./src/index.js",
   "exports": "./src/index.js",
+  "types": "./src/index.d.ts",
   "files": [
     "src"
   ],

--- a/src/calendar.d.ts
+++ b/src/calendar.d.ts
@@ -1,8 +1,17 @@
-export type CalendarProps = {
-    value?: Date | undefined;
-    mode?: string | undefined;
-    onSelect?: (() => void) | undefined;
-    weekdayFormat?: string | undefined;
-    arrowLeft?: (() => any) | undefined;
-    arrowRight?: (() => any) | undefined;
+type CalendarValues = {
+  single: Date
+  range: [Date, Date]
+}
+
+export type CalendarValue<M extends CalendarMode = CalendarMode> = CalendarValues[M]
+
+export type CalendarMode = "single" | "range"
+
+export type CalendarProps<M extends CalendarMode = CalendarMode> = {
+  value?: CalendarValue<M>
+  weekdayFormat?: "narrow" | "short" | "long"
+  arrowLeft?: () => any
+  arrowRight?: () => any
+  mode?: M
+  onSelect?: (nextValue: CalendarValue<M>) => void
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,6 @@
+import { JSX } from "preact"
+import { CalendarMode, CalendarProps } from "./calendar"
+
+export const Calendar: <M extends CalendarMode>(props: CalendarProps<M>) => JSX.Element
+
+export * from "./calendar"


### PR DESCRIPTION
Currently, the package does not provide any type definitions, which leads to the following error in TS projects:
> Could not find a declaration file for module '@preachjs/datepicker'.
> Try `npm i --save-dev @types/preachjs__datepicker` if it exists or add a new declaration (.d.ts) file containing ...

This PR adds type definition for the whole component and exports it in package.json (hopefully `types` is enough).
Additionally, the calendar props type was extended with the most exact and generic values.

The latter provides a handful type guard for the `value` prop and specific type for the argument inside `onSelect` callback:
```tsx
<Calendar
    mode="range"
    value={new Date()} // error: [Date, Date] expected
    onSelect={value => { 
        value // type: [Date, Date]
        value[2] // error: No element at index '2'
    }}
/>
```
```tsx
<Calendar
    mode={mode.value} // single | range
    onSelect={value => { 
        value // type: [Date, Date] | Date
    }}
/>
```

See a typescript version of the example in [this branch](https://github.com/ArturSharapov/datepicker/tree/example-ts) (can be run with `npm run example:dev --tsx`).